### PR TITLE
Fix alt text for APIsec University badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ src="https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExbnBtbmlkcDh1ZjM4Mndicjltc
 
 <p>
   <img src="assets/badges/google-people-management-essentials.png" width="120" alt="Google People Management Essentials" />
-  <img src="assets/badges/api-security-fundamentals-25-2-hours.png" width="120" alt="Google People Management Essentials" />
+  <img src="assets/badges/api-security-fundamentals-25-2-hours.png" width="120" alt="APIsec University - API Security Fundamentals (2.5 hours)" />
 </p>
 
 <!-- <p>


### PR DESCRIPTION
The APIsec University API Security Fundamentals badge had a copy-pasted
alt text from the Google People Management badge. Update it to describe
the actual certification.